### PR TITLE
Update domain mapping chanpter for use without plugins

### DIFF
--- a/en/multisite/README.md
+++ b/en/multisite/README.md
@@ -20,7 +20,7 @@ Doable but doesn't scale for big networks and is expensive
 
 ## Domain Mapping
 
-Domain mapping allows a blog on a multisite install to serve from any domain name. This way a blog does not have to be a subdirectory of the main install, or a subdomain.
+Domain mapping allows a blog on a multisite install to serve from any domain name. This way a blog does not have to be a subdirectory of the main install, or a subdomain. The WordPress Default supports Domain Mapping without Alias. Add the Domain in the blog-settings to the blog of the Network administration area.
 
 Often is it helpful - but not necessary, to set the `COOKIE_DOMAIN` constant to an empty string in your `wp-config.php`:
 
@@ -28,7 +28,7 @@ Often is it helpful - but not necessary, to set the `COOKIE_DOMAIN` constant to 
 
 Otherwise WordPress will always set it to your network’s `$current_site->domain`, which could cause issues in some situations.
 
-WordPress Core hopes to provide Domain Mapping in the future, but until then you can make use of one of the following plugins:
+WordPress Core hopes to provide Domain Alias Mapping in the future, but until then you can make use of one of the following plugins:
 
  * [Mercator - WordPress multisite domain mapping for the modern era.](https://github.com/humanmade/Mercator)
  * [WordPress MU Domain Mapping - Map any blog/site on a WordPressMU or WordPress 3.X network to an external domain.](https://wordpress.org/plugins/wordpress-mu-domain-mapping/)


### PR DESCRIPTION
Hi Tom.
A small update for the Domain Mapping chapter. This works on default of WP Core, no plugins necessary. Only for Domain Mapping is a plugin necessary.

Example:
![domain-mapping](https://cloud.githubusercontent.com/assets/133425/4704453/3a9dc4bc-5872-11e4-9c63-d102d5d0dd2c.png)

Best
