### PR TITLE
Update link to migrations (style change)

### DIFF
--- a/en/servers_and_deployment/README.md
+++ b/en/servers_and_deployment/README.md
@@ -16,7 +16,7 @@ Make sure your local environment is as similar to your production server as poss
 
 Consider using a [staging server](https://en.wikipedia.org/wiki/Staging_site) to help with this.
 
-If you're copying a database from development to production (or vice-versa), you'll need to change the URLs. See the [*Migrations*] (https://github.com/Tarendai/WordPress-The-Right-Way/blob/master/en/servers_and_deployment/migrations.md)section in this chapter.
+If you're copying a database from development to production (or vice-versa), you'll need to change the URLs. See the [*Migrations*](https://github.com/Tarendai/WordPress-The-Right-Way/blob/master/en/servers_and_deployment/migrations.md) section in this chapter.
 
 ## Use Version Control
 


### PR DESCRIPTION
On the live website/book, the style of the link to migrations does not work because of the wrong location of whitespaces. This should solve the problem.

![voila_capture 2015-10-06_08-48-17_a](https://cloud.githubusercontent.com/assets/1712222/10302847/6516878e-6c07-11e5-9265-da32081b7746.png)